### PR TITLE
 .city-select-content add style "box-sizing: border-box"

### DIFF
--- a/src/css/city-picker.css
+++ b/src/css/city-picker.css
@@ -105,6 +105,7 @@
     min-height: 10px;
     background-color: #fff;
     padding: 10px 15px;
+	box-sizing: border-box;
 }
 
 .city-select {


### PR DESCRIPTION
in case of no bootstrap in page, preventing the drop down menu in disorder.